### PR TITLE
Hot Fix: Response status for email account deletions.

### DIFF
--- a/src/Exceptions/DoesNotExistResponseException.php
+++ b/src/Exceptions/DoesNotExistResponseException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace ResellerClub\Exceptions;
+
+class DoesNotExistResponseException extends ApiException
+{
+}

--- a/src/Orders/EmailAccounts/Responses/DeletedResponse.php
+++ b/src/Orders/EmailAccounts/Responses/DeletedResponse.php
@@ -2,8 +2,70 @@
 
 namespace ResellerClub\Orders\EmailAccounts\Responses;
 
+use ResellerClub\Exceptions\DoesNotExistResponseException;
+use ResellerClub\Exceptions\MissingAttributeException;
+use ResellerClub\Exceptions\ResponseException;
 use ResellerClub\Response;
+use ResellerClub\Status;
 
 class DeletedResponse extends Response
 {
+    /**
+     * The created email account user.
+     *
+     * @param array $attributes
+     *
+     * @throws MissingAttributeException
+     * @throws DoesNotExistResponseException
+     * @throws ResponseException
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->throwExceptionIfWasNotSuccessful();
+    }
+
+    /**
+     * Get the response status.
+     *
+     * @return Status
+     */
+    public function status(): Status
+    {
+        if (!array_key_exists('status', $this->response)) {
+            throw new MissingAttributeException('status');
+        }
+
+        return new Status($this->response['status']);
+    }
+
+    /**
+     * Throws the appropriate exception if the response was not successful.
+     *
+     * @throws DoesNotExistResponseException
+     * @throws ResponseException
+     */
+    private function throwExceptionIfWasNotSuccessful()
+    {
+        // Not all responses contain a status it would seem, for example get business email.
+        if (! $this->wasSuccessful()) {
+            $this->throwDoesNotExistResponseIfEmailAddressNotFoundError();
+
+            throw new ResponseException($this->response['message']);
+        }
+    }
+
+    /**
+     * Checks to see if the email address does not exist error is in the response and throws a standardised exception.
+     *
+     * @throws DoesNotExistResponseException
+     */
+    private function throwDoesNotExistResponseIfEmailAddressNotFoundError()
+    {
+        if (array_key_exists('errorCode', $this->response) &&
+            $this->response['errorCode'] === 'emailaddress_does_not_exist') {
+            throw new DoesNotExistResponseException();
+        }
+    }
 }

--- a/tests/unit/Orders/EmailAccounts/EmailAccountTest.php
+++ b/tests/unit/Orders/EmailAccounts/EmailAccountTest.php
@@ -25,7 +25,12 @@ class EmailAccountTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                json_encode(['status' => 'Success'])),
+                json_encode([
+                    'response' => [
+                        'status' => 'Success'
+                    ]
+                ])
+            ),
         ]);
 
         $emailAccounts = new EmailAccount($this->api($mock));

--- a/tests/unit/Orders/EmailAccounts/Responses/DeletedResponseTest.php
+++ b/tests/unit/Orders/EmailAccounts/Responses/DeletedResponseTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Unit\Orders\EmailAccounts\Responses;
+
+use PHPUnit\Framework\TestCase;
+use ResellerClub\Exceptions\DoesNotExistResponseException;
+use ResellerClub\Exceptions\MissingAttributeException;
+use ResellerClub\Exceptions\ResponseException;
+use ResellerClub\Orders\EmailAccounts\Responses\DeletedResponse;
+use ResellerClub\Status;
+
+class DeletedResponseTest extends TestCase
+{
+    public function testMissingAttributeExceptionThrownWhenStatusNotSetInResponse()
+    {
+        try {
+            new DeletedResponse(['response' => []]);
+        } catch (MissingAttributeException $e) {
+            $this->assertEquals('Expected attribute [status] was not in response.', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('The missing attribute exception has not been thrown.');
+    }
+
+    public function testStatusSet()
+    {
+        $response = new DeletedResponse([
+            'response' => ['status' => 'SUCCESS']
+        ]);
+
+        $this->assertInstanceOf(Status::class, $response->status());
+        $this->assertEquals('success', (string) $response->status());
+    }
+
+    public function testDoesNotExistResponseThrownWhenEmailAddressErrorCodeFound()
+    {
+        $this->expectException(DoesNotExistResponseException::class);
+        new DeletedResponse([
+            'response' => [
+                'status' => 'FAILURE',
+                'message' => 'Email address test1@some-domain.co.uk does not exist',
+                'errorCode' => 'emailaddress_does_not_exist',
+            ]
+        ]);
+    }
+
+    public function testResponseExceptionThrownWhenNotSuccessful()
+    {
+        try {
+            new DeletedResponse([
+                'response' => [
+                    'status' => 'FAILURE',
+                    'message' => 'A failure has occurred.',
+                ]
+            ]);
+        } catch (ResponseException $e) {
+            $this->assertEquals('A failure has occurred.', $e->getMessage());
+
+            return;
+        }
+
+        $this->fail('The does not exist response exception was not thrown for the failure.');
+    }
+}

--- a/tests/unit/Orders/EmailForwarders/EmailForwarderTest.php
+++ b/tests/unit/Orders/EmailForwarders/EmailForwarderTest.php
@@ -23,7 +23,12 @@ class EmailForwarderTest extends TestCase
             new Response(
                 200,
                 ['Content-Type' => 'application/json'],
-                json_encode(['status' => 'Success'])),
+                json_encode([
+                    'response' => [
+                        'status' => 'Success'
+                    ]
+                ])
+            ),
         ]);
 
         $emailForwarders = new EmailForwarder($this->api($mock));


### PR DESCRIPTION
Added in a does not exist response exception, which is thrown when the email address does not exist when attempting to delete said email address.