### PR TITLE
WEB-2276: Delete email account response for removing account of bussiness email order.

### DIFF
--- a/src/Orders/BusinessEmails/Responses/DeletedEmailAccountResponse.php
+++ b/src/Orders/BusinessEmails/Responses/DeletedEmailAccountResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ResellerClub\Orders\BusinessEmails\Responses;
+
+use Money\Currency;
+use Money\Money;
+use ResellerClub\Orders\BusinessEmails\Responses\Concerns\HasAction;
+use ResellerClub\Response;
+
+/**
+ * @see https://manage.resellerclub.com/kb/answer/2159
+ */
+class DeletedEmailAccountResponse extends Response
+{
+    use HasAction;
+
+    /**
+     * Get the ID of the business email order.
+     *
+     * @return int
+     */
+    public function entityId(): int
+    {
+        return $this->entityid;
+    }
+
+    /**
+     * Gets the domain name that this business email order has been created for.
+     *
+     * @return string
+     */
+    public function domain(): string
+    {
+        return $this->description;
+    }
+}

--- a/tests/unit/Orders/BusinessEmails/Responses/DeletedEmailAccountResponseTest.php
+++ b/tests/unit/Orders/BusinessEmails/Responses/DeletedEmailAccountResponseTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Orders\BusinessEmails\Responses;
+
+use Money\Currency;
+use Money\Money;
+use PHPUnit\Framework\TestCase;
+use ResellerClub\Action;
+use ResellerClub\Orders\BusinessEmails\Responses\AddedEmailAccountResponse;
+use ResellerClub\Status;
+
+class DeletedEmailAccountResponseTest extends TestCase
+{
+    /**
+     * @var RenewalResponse
+     */
+    private $response;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->response = new AddedEmailAccountResponse([
+            'entityid'          => '80239999',
+            'description'       => 'test-domain-3.co.uk.onlyfordemo.com',
+            'actionstatus'      => 'ExecutionStarted',
+            'actionstatusdesc'  => 'Your email account deletion request will be processed shortly.',
+            'actiontypedesc'    => 'Deletion of 1 email accounts for test-domain-3.co.uk.onlyfordemo.com',
+            'status'            => 'Success',
+            'eaqid'             => '471836050',
+            'actiontype'        => 'DeleteEmailAccount'
+        ]);
+    }
+
+    public function testItCanGetAction()
+    {
+        $this->assertInstanceOf(Action::class, $this->response->action());
+        $this->assertEquals(471836050, $this->response->action()->id());
+        $this->assertEquals('DeleteEmailAccount', $this->response->action()->type());
+        $this->assertEquals(
+            'Deletion of 1 email accounts for test-domain-3.co.uk.onlyfordemo.com',
+            $this->response->action()->typeDescription()
+        );
+        $this->assertEquals(
+            'ExecutionStarted',
+            $this->response->action()->status()
+        );
+        $this->assertEquals(
+            'Your email account deletion request will be processed shortly.',
+            $this->response->action()->statusDescription()
+        );
+    }
+
+    public function testItCanGetEntityId()
+    {
+        $this->assertEquals(80239999, $this->response->entityId());
+    }
+
+    public function testItCanGetDomain()
+    {
+        $this->assertEquals('test-domain-3.co.uk.onlyfordemo.com', $this->response->domain());
+    }
+
+    public function testItCanGetStatus()
+    {
+        $this->assertInstanceOf(Status::class, $this->response->status());
+        $this->assertEquals('success', (string) $this->response->status());
+    }
+}


### PR DESCRIPTION
Added the deleted email account response for deleting email accounts of a business email order.