### PR TITLE
Add ability to add and update DNS A records

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,28 @@ try {
 1. [How to create an account on the staging platform](https://manage.resellerclub.com/kb/node/173)
 1. [Where to find and regenerate an API key](https://manage.resellerclub.com/kb/node/3188)
 
+#### Add an A record
+[API Documentation](https://manage.resellerclub.com/kb/node/1093)
+
+```php
+try {
+    $ttl = new ResellerClub\TimeToLive(86400);
+    $request = new ResellerClub\Dns\A\Requests\AddRequest(
+        $domain = 'another-testing-domain.com',
+        $record = 'test',
+        new ResellerClub\IPv4Address('127.0.0.1'),
+        $ttl
+    );
+
+    $response = $api->aRecord()->add($request);
+
+    // @todo - Handle the successful response within your codebase.
+
+} catch(ResellerClub\Exceptions\ApiException $e) {
+    // @todo - Handle the exception within your codebase.
+}
+```
+
 #### Update a CNAME record
 [API Documentation](https://manage.resellerclub.com/kb/node/1101)
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -4,6 +4,7 @@ namespace ResellerClub;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
+use ResellerClub\Dns\A\ARecord;
 use ResellerClub\Dns\Cname\CnameRecord;
 use ResellerClub\Orders\BusinessEmails\BusinessEmailOrder;
 use ResellerClub\Orders\Domains\DomainOrder;
@@ -118,6 +119,16 @@ class Api
     public function cnameRecord(): CnameRecord
     {
         return new CnameRecord($this);
+    }
+
+    /**
+     * Return an 'A' DNS record instance.
+     *
+     * @return ARecord
+     */
+    public function aRecord(): ARecord
+    {
+        return new ARecord($this);
     }
 
     /**

--- a/src/Dns/A/ARecord.php
+++ b/src/Dns/A/ARecord.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace ResellerClub\Dns\A;
+
+use ResellerClub\Api;
+use ResellerClub\Dns\A\Requests\AddRequest;
+use ResellerClub\Dns\A\Requests\UpdateRequest;
+use ResellerClub\Dns\A\Responses\AddResponse;
+use ResellerClub\Dns\A\Responses\UpdateResponse;
+
+class ARecord
+{
+    /**
+     * @var Api
+     */
+    private $api;
+
+    /**
+     * @param Api $api
+     */
+    public function __construct(Api $api)
+    {
+        $this->api = $api;
+    }
+
+    /**
+     * Add a new A record.
+     *
+     * @see https://manage.resellerclub.com/kb/node/1093
+     *
+     * @param AddRequest $request
+     *
+     * @return AddResponse
+     */
+    public function add(AddRequest $request): AddResponse
+    {
+        $response = $this->api->post(
+            'dns/manage/add-ipv4-record.json',
+            [
+                'domain-name'       => (string) $request->domain(),
+                'host'              => (string) $request->record(),
+                'value'             => (string) $request->value(),
+                'ttl'               => (int) $request->ttl()->integer(),
+            ]
+        );
+
+        return AddResponse::fromApiResponse($response);
+    }
+
+    /**
+     * Update an existing A record.
+     *
+     * @see https://manage.resellerclub.com/kb/node/1098
+     *
+     * @param UpdateRequest $request
+     *
+     * @return UpdateResponse
+     */
+    public function update(UpdateRequest $request): UpdateResponse
+    {
+        $response = $this->api->post(
+            'dns/manage/update-ipv4-record.json',
+            [
+                'domain-name'       => (string) $request->domain(),
+                'host'              => (string) $request->record(),
+                'current-value'     => (string) $request->currentValue(),
+                'new-value'         => (string) $request->newValue(),
+                'ttl'               => (int) $request->ttl()->integer(),
+            ]
+        );
+
+        return UpdateResponse::fromApiResponse($response);
+    }
+}

--- a/src/Dns/A/Requests/AddRequest.php
+++ b/src/Dns/A/Requests/AddRequest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace ResellerClub\Dns\A\Requests;
+
+use ResellerClub\IPv4Address;
+use ResellerClub\Response;
+use ResellerClub\TimeToLive;
+
+class AddRequest extends Response
+{
+    /**
+     * Top level domain name whose records you want to add
+     * e.g. mydomain.com.
+     *
+     * @var string
+     */
+    private $domain;
+
+    /**
+     * Record you want to add
+     * e.g. "www" or "mysubdomain".
+     *
+     * @var string
+     */
+    private $record;
+
+    /**
+     * Value of this new record e.g. "127.0.0.1".
+     *
+     * @var IPv4Address
+     */
+    private $value;
+
+    /**
+     * Time-to-live object for this DNS record.
+     *
+     * @var TimeToLive
+     */
+    private $ttl;
+
+    /**
+     * AddRequest constructor.
+     *
+     * @param string          $domain
+     * @param string          $record
+     * @param IPv4Address     $value
+     * @param TimeToLive|null $ttl
+     */
+    public function __construct(string $domain, string $record, IPv4Address $value, TimeToLive $ttl = null)
+    {
+        $this->domain = $domain;
+        $this->record = $record;
+        $this->value = $value;
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * @return string
+     */
+    public function domain(): string
+    {
+        return $this->domain;
+    }
+
+    /**
+     * @return string
+     */
+    public function record(): string
+    {
+        return $this->record;
+    }
+
+    /**
+     * @return IPv4Address
+     */
+    public function value(): IPv4Address
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return TimeToLive
+     */
+    public function ttl(): TimeToLive
+    {
+        return ($this->ttl) ? $this->ttl : TimeToLive::defaultTtl();
+    }
+}

--- a/src/Dns/A/Requests/UpdateRequest.php
+++ b/src/Dns/A/Requests/UpdateRequest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace ResellerClub\Dns\A\Requests;
+
+use ResellerClub\IPv4Address;
+use ResellerClub\Response;
+use ResellerClub\TimeToLive;
+
+class UpdateRequest extends Response
+{
+    /**
+     * Top level domain name whose records you want to update
+     * e.g. mydomain.com.
+     *
+     * @var string
+     */
+    private $domain;
+
+    /**
+     * Record you want to update
+     * e.g. "www" or "mysubdomain".
+     *
+     * @var string
+     */
+    private $record;
+
+    /**
+     * Current value of this record.
+     *
+     * @var IPv4Address
+     */
+    private $currentValue;
+
+    /**
+     * New value of this record.
+     *
+     * @var IPv4Address
+     */
+    private $newValue;
+
+    /**
+     * Time-to-live object for this DNS record.
+     *
+     * @var TimeToLive
+     */
+    private $ttl;
+
+    /**
+     * UpdateRequest constructor.
+     *
+     * @param string          $domain
+     * @param string          $record
+     * @param IPv4Address     $currentValue
+     * @param IPv4Address     $newValue
+     * @param TimeToLive|null $ttl
+     */
+    public function __construct(string $domain, string $record, IPv4Address $currentValue, IPv4Address $newValue, TimeToLive $ttl = null)
+    {
+        $this->domain = $domain;
+        $this->record = $record;
+        $this->currentValue = $currentValue;
+        $this->newValue = $newValue;
+        $this->ttl = $ttl;
+    }
+
+    /**
+     * @return string
+     */
+    public function domain(): string
+    {
+        return $this->domain;
+    }
+
+    /**
+     * @return string
+     */
+    public function record(): string
+    {
+        return $this->record;
+    }
+
+    /**
+     * @return IPv4Address
+     */
+    public function currentValue(): IPv4Address
+    {
+        return $this->currentValue;
+    }
+
+    /**
+     * @return IPv4Address
+     */
+    public function newValue(): IPv4Address
+    {
+        return $this->newValue;
+    }
+
+    /**
+     * @return TimeToLive
+     */
+    public function ttl(): TimeToLive
+    {
+        return ($this->ttl) ? $this->ttl : TimeToLive::defaultTtl();
+    }
+}

--- a/src/Dns/A/Responses/AddResponse.php
+++ b/src/Dns/A/Responses/AddResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ResellerClub\Dns\A\Responses;
+
+use ResellerClub\Message;
+use ResellerClub\Response;
+
+class AddResponse extends Response
+{
+    /**
+     * Get the response message.
+     *
+     * @return Message
+     */
+    public function message(): Message
+    {
+        return new Message($this->attributes['msg']);
+    }
+}

--- a/src/Dns/A/Responses/UpdateResponse.php
+++ b/src/Dns/A/Responses/UpdateResponse.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ResellerClub\Dns\A\Responses;
+
+use ResellerClub\Message;
+use ResellerClub\Response;
+
+class UpdateResponse extends Response
+{
+    /**
+     * Get the response message.
+     *
+     * @return Message
+     */
+    public function message(): Message
+    {
+        return new Message($this->attributes['msg']);
+    }
+}

--- a/src/IPv4Address.php
+++ b/src/IPv4Address.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ResellerClub;
+
+use InvalidArgumentException;
+
+class IPv4Address
+{
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * Create a new IPv4 instance.
+     *
+     * @param string $value
+     *
+     * @throws InvalidArgumentException
+     */
+    public function __construct(string $value)
+    {
+        if (filter_var($value, FILTER_VALIDATE_IP,FILTER_FLAG_IPV4) === false) {
+            throw new InvalidArgumentException("Value [{$value}] is not a valid IPv4 address.");
+        }
+
+        $this->value = $value;
+    }
+
+    /**
+     * Get the string representation of this IPv4 address.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        return $this->value;
+    }
+}

--- a/tests/unit/Dns/A/ARecordTest.php
+++ b/tests/unit/Dns/A/ARecordTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Tests\Unit\Dns\A;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use ResellerClub\Api;
+use ResellerClub\Config;
+use ResellerClub\Dns\A\ARecord;
+use ResellerClub\Dns\A\Requests\AddRequest;
+use ResellerClub\Dns\A\Requests\UpdateRequest;
+use ResellerClub\Dns\A\Responses\AddResponse;
+use ResellerClub\Dns\A\Responses\UpdateResponse;
+use ResellerClub\IPv4Address;
+use ResellerClub\TimeToLive;
+
+class ARecordTest extends TestCase
+{
+    public function testAddInstance()
+    {
+        $ARecord = new ARecord($this->api($this->mockResponse()));
+
+        $addRequest = new AddRequest(
+            'mytestdomain.com',
+            'www',
+            new IPv4Address('127.0.0.1'),
+            new TimeToLive(7200)
+        );
+
+        $this->assertInstanceOf(AddResponse::class, $ARecord->add($addRequest));
+    }
+
+    public function testUpdateInstance()
+    {
+        $ARecord = new ARecord($this->api($this->mockResponse()));
+
+        $updateRequest = new UpdateRequest(
+            'mytestdomain.com',
+            'www',
+            new IPv4Address('127.0.0.1'),
+            new IPv4Address('192.168.0.1'),
+            new TimeToLive(7200)
+        );
+
+        $this->assertInstanceOf(UpdateResponse::class, $ARecord->update($updateRequest));
+    }
+
+    private function api(MockHandler $mock): Api
+    {
+        $handler = HandlerStack::create($mock);
+
+        return new Api(
+            new Config(123, 'api_key', true),
+            new Client(['handler' => $handler])
+        );
+    }
+
+    /**
+     * @return MockHandler
+     */
+    private function mockResponse(): MockHandler
+    {
+        return new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode([
+                    'response' => [
+                        'status' => 'Success',
+                    ],
+                ])
+            ),
+        ]);
+    }
+}

--- a/tests/unit/Dns/A/Requests/AddRequestTest.php
+++ b/tests/unit/Dns/A/Requests/AddRequestTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Tests\Unit\Dns\A\Requests;
+
+use PHPUnit\Framework\TestCase;
+use ResellerClub\Dns\A\Requests\AddRequest;
+use ResellerClub\IPv4Address;
+use ResellerClub\TimeToLive;
+
+class AddRequestTest extends TestCase
+{
+    public function testInstantiation()
+    {
+        $ttl = TimeToLive::defaultTtl();
+        $request = new AddRequest(
+            'test.com',
+            'www',
+            new IPv4Address('127.0.0.1'),
+            $ttl
+        );
+
+        $this->assertInstanceOf(AddRequest::class, $request);
+    }
+
+    public function testInstantiationWithoutTTL()
+    {
+        $request = new AddRequest(
+            'test.com',
+            'www',
+            new IPv4Address('127.0.0.1')
+        );
+
+        $this->assertInstanceOf(AddRequest::class, $request);
+    }
+
+    public function testGetters()
+    {
+        $ttl = TimeToLive::defaultTtl();
+        $request = new AddRequest(
+            'test.com',
+            'www',
+            new IPv4Address('127.0.0.1'),
+            $ttl
+        );
+
+        $this->assertInternalType('string', $request->domain());
+        $this->assertInternalType('string', $request->record());
+        $this->assertInstanceOf(IPv4Address::class, $request->value());
+        $this->assertInstanceOf(TimeToLive::class, $request->ttl());
+    }
+
+    public function testGettersWithoutTTL()
+    {
+        $request = new AddRequest(
+            'test.com',
+            'www',
+            new IPv4Address('127.0.0.1')
+        );
+
+        $this->assertInternalType('string', $request->domain());
+        $this->assertInternalType('string', $request->record());
+        $this->assertInstanceOf(IPv4Address::class, $request->value());
+        $this->assertInstanceOf(TimeToLive::class, $request->ttl());
+        $this->assertEquals((string) $request->ttl(), TimeToLive::DEFAULT_TTL);
+    }
+
+    public function testGettersWithBlankRecord()
+    {
+        $ttl = TimeToLive::defaultTtl();
+        $request = new AddRequest(
+            'test.com',
+            '',
+            new IPv4Address('127.0.0.1'),
+            $ttl
+        );
+
+        $this->assertInternalType('string', $request->domain());
+        $this->assertInternalType('string', $request->record());
+        $this->assertInstanceOf(IPv4Address::class, $request->value());
+        $this->assertInstanceOf(TimeToLive::class, $request->ttl());
+    }
+}

--- a/tests/unit/Dns/A/Requests/UpdateRequestTest.php
+++ b/tests/unit/Dns/A/Requests/UpdateRequestTest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests\Unit\Dns\A\Requests;
+
+use PHPUnit\Framework\TestCase;
+use ResellerClub\Dns\A\Requests\UpdateRequest;
+use ResellerClub\IPv4Address;
+use ResellerClub\TimeToLive;
+
+class UpdateRequestTest extends TestCase
+{
+    public function testInstantiation()
+    {
+        $ttl = TimeToLive::defaultTtl();
+        $request = new UpdateRequest(
+            'test.com',
+            'www',
+            new IPv4Address('127.0.0.1'),
+            new IPv4Address('192.168.0.1'),
+            $ttl
+        );
+
+        $this->assertInstanceOf(UpdateRequest::class, $request);
+    }
+
+    public function testInstantiationWithoutTTL()
+    {
+        $request = new UpdateRequest(
+            'test.com',
+            'www',
+            new IPv4Address('127.0.0.1'),
+            new IPv4Address('192.168.0.1')
+        );
+
+        $this->assertInstanceOf(UpdateRequest::class, $request);
+    }
+
+    public function testGetters()
+    {
+        $ttl = TimeToLive::defaultTtl();
+        $request = new UpdateRequest(
+            'test.com',
+            'www',
+            new IPv4Address('127.0.0.1'),
+            new IPv4Address('192.168.0.1'),
+            $ttl
+        );
+
+        $this->assertInternalType('string', $request->domain());
+        $this->assertInternalType('string', $request->record());
+        $this->assertInstanceOf(IPv4Address::class, $request->currentValue());
+        $this->assertInstanceOf(IPv4Address::class, $request->newValue());
+        $this->assertInstanceOf(TimeToLive::class, $request->ttl());
+    }
+
+    public function testGettersWithoutTTL()
+    {
+        $request = new UpdateRequest(
+            'test.com',
+            'www',
+            new IPv4Address('127.0.0.1'),
+            new IPv4Address('192.168.0.1')
+        );
+
+        $this->assertInternalType('string', $request->domain());
+        $this->assertInternalType('string', $request->record());
+        $this->assertInstanceOf(IPv4Address::class, $request->currentValue());
+        $this->assertInstanceOf(IPv4Address::class, $request->newValue());
+        $this->assertInstanceOf(TimeToLive::class, $request->ttl());
+        $this->assertEquals((string) $request->ttl(), TimeToLive::DEFAULT_TTL);
+    }
+}

--- a/tests/unit/IPv4AddressTest.php
+++ b/tests/unit/IPv4AddressTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use ResellerClub\IPv4Address;
+
+class IPv4AddressTest extends TestCase
+{
+    public function testCanCreateNewInstance()
+    {
+        $address = new IPv4Address('127.0.0.1');
+
+        $this->assertEquals('127.0.0.1', (string) $address);
+    }
+
+    public function testInvalidIPv4AddressThrowsException()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        /**
+         * Missing 4th octet
+         */
+        new IPv4Address('127.0.0');
+    }
+
+    public function testInvalidIPv4AddressThrowsException2()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        /**
+         * Added 5th octet
+         */
+        new IPv4Address('127.0.0.0.1');
+    }
+
+    public function testInvalidIPv4AddressThrowsException3()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        /**
+         * IPv6 Address
+         */
+        new IPv4Address('::1/128');
+    }
+}


### PR DESCRIPTION
Similar functionality to the previous CNAME update.
Includes unit tests.
I have tested (by installing the feature branch into our main codebase) the API calls and they behave as expected.