### PR TITLE
[Feature] Add Reset password and updating email account information

### DIFF
--- a/src/Orders/EmailAccounts/EmailAccount.php
+++ b/src/Orders/EmailAccounts/EmailAccount.php
@@ -5,8 +5,12 @@ namespace ResellerClub\Orders\EmailAccounts;
 use ResellerClub\Api;
 use ResellerClub\Orders\EmailAccounts\Requests\CreateRequest;
 use ResellerClub\Orders\EmailAccounts\Requests\DeleteRequest;
+use ResellerClub\Orders\EmailAccounts\Requests\ResetPasswordRequest;
+use ResellerClub\Orders\EmailAccounts\Requests\UpdateDetailsRequest;
 use ResellerClub\Orders\EmailAccounts\Responses\CreateResponse;
 use ResellerClub\Orders\EmailAccounts\Responses\DeletedResponse;
+use ResellerClub\Orders\EmailAccounts\Responses\ResetPasswordResponse;
+use ResellerClub\Orders\EmailAccounts\Responses\UpdateDetailsResponse;
 
 class EmailAccount
 {
@@ -73,5 +77,50 @@ class EmailAccount
         );
 
         return DeletedResponse::fromApiResponse($response);
+    }
+
+    /**
+     * Makes a POST request to ResellerClub's 'update' email accounts.
+     *
+     * @see https://manage.resellerclub.com/kb/answer/1040
+     *
+     * @param UpdateDetailsRequest $request
+     * @return UpdateDetailsResponse
+     */
+    public function updateDetails(UpdateDetailsRequest $request): UpdateDetailsResponse
+    {
+        $response = $this->api->post(
+            'mail/user/modify.json',
+            [
+                'order-id' => $request->orderId(),
+                'email' => $request->emailAddress(),
+                'notification-email' => $request->notificationEmailAddress(),
+                'first-name' => $request->firstName(),
+                'last-name' => $request->lastName(),
+            ]
+        );
+
+        return UpdateDetailsResponse::fromApiResponse($response);
+    }
+
+    /**
+     * Makes a POST request to ResellerClub's 'reset-password' email account.
+     *
+     * @see https://manage.resellerclub.com/kb/answer/1118
+     *
+     * @param ResetPasswordRequest $request
+     * @return ResetPasswordResponse
+     */
+    public function resetPassword(ResetPasswordRequest $request): ResetPasswordResponse
+    {
+        $response = $this->api->post(
+            'mail/user/reset-password.json',
+            [
+                'order-id' => $request->orderId(),
+                'email' => $request->emailAddress(),
+            ]
+        );
+
+        return ResetPasswordResponse::fromApiResponse($response);
     }
 }

--- a/src/Orders/EmailAccounts/EmailAccount.php
+++ b/src/Orders/EmailAccounts/EmailAccount.php
@@ -93,8 +93,8 @@ class EmailAccount
             'mail/user/modify.json',
             [
                 'order-id' => $request->orderId(),
-                'email' => $request->emailAddress(),
-                'notification-email' => $request->notificationEmailAddress(),
+                'email' => (string) $request->emailAddress(),
+                'notification-email' => (string) $request->notificationEmailAddress(),
                 'first-name' => $request->firstName(),
                 'last-name' => $request->lastName(),
             ]
@@ -117,7 +117,7 @@ class EmailAccount
             'mail/user/reset-password.json',
             [
                 'order-id' => $request->orderId(),
-                'email' => $request->emailAddress(),
+                'email' => (string) $request->emailAddress(),
             ]
         );
 

--- a/src/Orders/EmailAccounts/Requests/ResetPasswordRequest.php
+++ b/src/Orders/EmailAccounts/Requests/ResetPasswordRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ResellerClub\Orders\EmailAccounts\Requests;
+
+use ResellerClub\EmailAddress;
+use ResellerClub\Orders\Order;
+
+class ResetPasswordRequest
+{
+    /**
+     * @var Order
+     */
+    private $order;
+
+    /**
+     * @var EmailAddress
+     */
+    private $emailAddress;
+
+    /**
+     * ResetPassword constructor.
+     *
+     * @param Order $order
+     * @param EmailAddress $emailAddress
+     */
+    public function __construct(Order $order, EmailAddress $emailAddress)
+    {
+        $this->order = $order;
+        $this->emailAddress = $emailAddress;
+    }
+
+    /**
+     * Get the ID of the order.
+     *
+     * @return int
+     */
+    public function orderId(): int
+    {
+        return $this->order->id();
+    }
+
+    /**
+     * Get the email address of the password reset.
+     *
+     * @return EmailAddress
+     */
+    public function emailAddress(): EmailAddress
+    {
+        return $this->emailAddress;
+    }
+}

--- a/src/Orders/EmailAccounts/Requests/UpdateDetailsRequest.php
+++ b/src/Orders/EmailAccounts/Requests/UpdateDetailsRequest.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace ResellerClub\Orders\EmailAccounts\Requests;
+
+use ResellerClub\EmailAddress;
+use ResellerClub\Orders\Order;
+
+class UpdateDetailsRequest
+{
+    /**
+     * @var Order
+     */
+    private $order;
+
+    /**
+     * @var string
+     */
+    private $emailAddress;
+
+    /**
+     * @var string
+     */
+    private $notificationEmailAddress;
+
+    /**
+     * @var string
+     */
+    private $firstName;
+
+    /**
+     * @var string
+     */
+    private $lastName;
+
+    /**
+     * UpdateDetails constructor.
+     *
+     * @param Order $order
+     * @param EmailAddress $emailAddress
+     * @param EmailAddress $notificationEmailAddress
+     * @param string $firstName
+     * @param string $lastName
+     */
+    public function __construct(Order $order, EmailAddress $emailAddress, EmailAddress $notificationEmailAddress, string $firstName, string $lastName)
+    {
+        $this->order = $order;
+        $this->emailAddress = $emailAddress;
+        $this->notificationEmailAddress = $notificationEmailAddress;
+        $this->firstName = $firstName;
+        $this->lastName = $lastName;
+    }
+
+    /**
+     * Get the ID of the order.
+     *
+     * @return int
+     */
+    public function orderId(): int
+    {
+        return $this->order->id();
+    }
+
+    /**
+     * Get the email address of the business email account.
+     *
+     * @return EmailAddress
+     */
+    public function emailAddress(): EmailAddress
+    {
+        return $this->emailAddress;
+    }
+
+    /**
+     * Get the notification email address of the business email account.
+     *
+     * @return EmailAddress
+     */
+    public function notificationEmailAddress(): EmailAddress
+    {
+        return $this->notificationEmailAddress;
+    }
+
+    /**
+     * Get the first name of the business email account.
+     *
+     * @return string
+     */
+    public function firstName(): string
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * Get the last name of the business email account.
+     *
+     * @return string
+     */
+    public function lastName(): string
+    {
+        return $this->lastName;
+    }
+}

--- a/src/Orders/EmailAccounts/Responses/ResetPasswordResponse.php
+++ b/src/Orders/EmailAccounts/Responses/ResetPasswordResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace ResellerClub\Orders\EmailAccounts\Responses;
+
+use ResellerClub\Exceptions\DoesNotExistResponseException;
+use ResellerClub\Exceptions\MissingAttributeException;
+use ResellerClub\Exceptions\ResponseException;
+use ResellerClub\Response;
+use ResellerClub\Status;
+
+class ResetPasswordResponse extends Response
+{
+    /**
+     * The updated email account.
+     *
+     * @param array $attributes
+     *
+     * @throws MissingAttributeException
+     * @throws DoesNotExistResponseException
+     * @throws ResponseException
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->throwExceptionIfNotSuccessful();
+    }
+
+    /**
+     * Get the response status.
+     *
+     * @return Status
+     */
+    public function status(): Status
+    {
+        if (!array_key_exists('status', $this->response)) {
+            throw new MissingAttributeException('status');
+        }
+
+        return new Status($this->response['status']);
+    }
+
+    /**
+     * ResellerClub will provide a password for you to use, this is output in a string
+     *
+     * @return string
+     */
+    public function getPassword(): string
+    {
+        if (!array_key_exists('data', $this->response)) {
+            throw new MissingAttributeException('data');
+        }
+
+        return $this->response['data'];
+    }
+
+    /**
+     * Throws the appropriate exception if the response was not successful.
+     *
+     * @throws DoesNotExistResponseException
+     * @throws ResponseException
+     */
+    private function throwExceptionIfNotSuccessful()
+    {
+        // Not all responses contain a status it would seem, for example get business email.
+        if (!$this->wasSuccessful()) {
+            throw new ResponseException($this->response['message']);
+        }
+    }
+}

--- a/src/Orders/EmailAccounts/Responses/UpdateDetailsResponse.php
+++ b/src/Orders/EmailAccounts/Responses/UpdateDetailsResponse.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace ResellerClub\Orders\EmailAccounts\Responses;
+
+use ResellerClub\Exceptions\DoesNotExistResponseException;
+use ResellerClub\Exceptions\MissingAttributeException;
+use ResellerClub\Exceptions\ResponseException;
+use ResellerClub\Response;
+use ResellerClub\Status;
+
+class UpdateDetailsResponse extends Response
+{
+    /**
+     * The updated email account.
+     *
+     * @param array $attributes
+     *
+     * @throws MissingAttributeException
+     * @throws DoesNotExistResponseException
+     * @throws ResponseException
+     */
+    public function __construct(array $attributes = [])
+    {
+        parent::__construct($attributes);
+
+        $this->throwExceptionIfWasNotSuccessful();
+    }
+
+    /**
+     * Get the response status.
+     *
+     * @return Status
+     */
+    public function status(): Status
+    {
+        if (!array_key_exists('status', $this->response)) {
+            throw new MissingAttributeException('status');
+        }
+
+        return new Status($this->response['status']);
+    }
+
+    /**
+     * Throws the appropriate exception if the response was not successful.
+     *
+     * @throws DoesNotExistResponseException
+     * @throws ResponseException
+     */
+    private function throwExceptionIfWasNotSuccessful()
+    {
+        // Not all responses contain a status it would seem, for example get business email.
+        if (!$this->wasSuccessful()) {
+            throw new ResponseException($this->response['message']);
+        }
+    }
+}

--- a/src/Orders/EmailAccounts/Responses/UpdateDetailsResponse.php
+++ b/src/Orders/EmailAccounts/Responses/UpdateDetailsResponse.php
@@ -23,7 +23,7 @@ class UpdateDetailsResponse extends Response
     {
         parent::__construct($attributes);
 
-        $this->throwExceptionIfWasNotSuccessful();
+        $this->throwExceptionIfNotSuccessful();
     }
 
     /**
@@ -46,7 +46,7 @@ class UpdateDetailsResponse extends Response
      * @throws DoesNotExistResponseException
      * @throws ResponseException
      */
-    private function throwExceptionIfWasNotSuccessful()
+    private function throwExceptionIfNotSuccessful()
     {
         // Not all responses contain a status it would seem, for example get business email.
         if (!$this->wasSuccessful()) {

--- a/tests/unit/Orders/EmailAccounts/EmailAccountTest.php
+++ b/tests/unit/Orders/EmailAccounts/EmailAccountTest.php
@@ -13,8 +13,12 @@ use ResellerClub\EmailAddress;
 use ResellerClub\Orders\EmailAccounts\EmailAccount;
 use ResellerClub\Orders\EmailAccounts\Requests\CreateRequest;
 use ResellerClub\Orders\EmailAccounts\Requests\DeleteRequest;
+use ResellerClub\Orders\EmailAccounts\Requests\ResetPasswordRequest;
+use ResellerClub\Orders\EmailAccounts\Requests\UpdateDetailsRequest;
 use ResellerClub\Orders\EmailAccounts\Responses\CreateResponse;
 use ResellerClub\Orders\EmailAccounts\Responses\DeletedResponse;
+use ResellerClub\Orders\EmailAccounts\Responses\ResetPasswordResponse;
+use ResellerClub\Orders\EmailAccounts\Responses\UpdateDetailsResponse;
 use ResellerClub\Orders\Order;
 
 class EmailAccountTest extends TestCase
@@ -107,6 +111,121 @@ class EmailAccountTest extends TestCase
                     $languageCode = 'en'
                 )
             )
+        );
+    }
+
+    public function testUpdatingEmailDetails()
+    {
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode([
+                    'response' => [
+                        'status' => 'Success',
+                    ],
+                ])
+            ),
+        ]);
+
+        $emailAccounts = new EmailAccount($this->api($mock));
+
+        $this->assertInstanceOf(
+            UpdateDetailsResponse::class,
+            $emailAccounts->updateDetails(
+                new UpdateDetailsRequest(
+                    new Order($id = 123),
+                    new EmailAddress($email = 'john.doe@my-domain.co.uk'),
+                    new EmailAddress($email = 'jon.doe@my-new-domain.co.uk'),
+                    'Jon',
+                    'Doe'
+                )
+            )
+        );
+    }
+
+    public function testGetStatusOfUpdatingDetails()
+    {
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode([
+                    'response' => [
+                        'status' => 'Success',
+                    ],
+                ])
+            ),
+        ]);
+
+        $emailAccounts = new EmailAccount($this->api($mock));
+
+        $this->assertEquals(
+            true,
+            $emailAccounts->updateDetails(
+                new UpdateDetailsRequest(
+                    new Order($id = 123),
+                    new EmailAddress($email = 'john.doe@my-domain.co.uk'),
+                    new EmailAddress($email = 'jon.doe@my-new-domain.co.uk'),
+                    'Jon',
+                    'Doe'
+                )
+            )->wasSuccessful()
+        );
+    }
+
+    public function testResponseFromEmailPasswordReset()
+    {
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode([
+                    'response' => [
+                        'status' => 'Success',
+                        'data' => 'myT35tP@55word',
+                    ],
+                ])
+            ),
+        ]);
+
+        $emailAccounts = new EmailAccount($this->api($mock));
+
+        $this->assertInstanceOf(
+            ResetPasswordResponse::class,
+            $emailAccounts->resetPassword(
+                new ResetPasswordRequest(
+                    new Order($id = 123),
+                    new EmailAddress($email = 'john.doe@my-domain.co.uk')
+                )
+            )
+        );
+    }
+
+    public function testPasswordResetHasNewPassword()
+    {
+        $mock = new MockHandler([
+            new Response(
+                200,
+                ['Content-Type' => 'application/json'],
+                json_encode([
+                    'response' => [
+                        'status' => 'Success',
+                        'data' => 'myT35tP@55word',
+                    ],
+                ])
+            ),
+        ]);
+
+        $emailAccounts = new EmailAccount($this->api($mock));
+
+        $this->assertEquals('myT35tP@55word',
+            $emailAccounts->resetPassword(
+                new ResetPasswordRequest(
+                    new Order($id = 123),
+                    new EmailAddress($email = 'john.doe@my-domain.co.uk')
+                )
+            )->getPassword()
         );
     }
 


### PR DESCRIPTION
This enables the ability to reset a password for a mailbox along with updating the mailbox details.  

Updatable Detail information: 
- Notification address
- First Name
- Last Name

Password Resets will provide a password generated by ResellerClub Directly, this can be accessed using **_getPassword_** on **ResetPasswordResponse**